### PR TITLE
- Fix service ordering for network setup

### DIFF
--- a/systemd/azure-li-network.service
+++ b/systemd/azure-li-network.service
@@ -2,7 +2,8 @@
 Description=Setup of Azure Li/VLi network configuration
 ConditionPathExists=/.azure-li-network.trigger
 After=azure-li-config-lookup.service
-Before=network.target
+Before=network-pre.target
+Wants=network-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
  + The network setup needs to be written before any of the netwroking
    services are started by systemd, or we have to explicitly restart the
    networking. This order is only guaranteed with the network-pre.target