### PR TITLE
Let services report result status

### DIFF
--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -32,7 +32,7 @@ class Defaults(object):
 
     @classmethod
     def get_status_report_directory(self):
-        return '/etc/azure_li_services'
+        return '/var/lib/azure_li_services'
 
     @classmethod
     def get_config_file(self):

--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -31,6 +31,10 @@ class Defaults(object):
         return '/etc/suse_firstboot_config.yaml'
 
     @classmethod
+    def get_status_report_directory(self):
+        return '/etc/azure_li_services'
+
+    @classmethod
     def get_config_file(self):
         """
         Provides config file as stored locally

--- a/azure_li_services/status_report.py
+++ b/azure_li_services/status_report.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of azure-li-services.
+#
+# azure-li-services is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# azure-li-services is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import yaml
+
+# project
+from azure_li_services.path import Path
+from azure_li_services.defaults import Defaults
+
+
+class StatusReport(object):
+    """
+    **Implements status report interface**
+
+    Creating an instance of StatusReport will initialize the
+    provided service name with a default failed state. It's
+    in the responsibility of the service implementation to
+    set the success state when appropriate.
+
+    :param str service_name: name of the service
+    """
+    def __init__(self, service_name):
+        self.status = {
+            service_name: {
+                'success': None
+            }
+        }
+        self.service_name = service_name
+        self.status_directory = Defaults.get_status_report_directory()
+        self.status_file = os.sep.join(
+            [self.status_directory, self.service_name + '.report.yaml']
+        )
+        if not os.path.exists(self.status_directory):
+            Path.create(self.status_directory)
+
+        self.set_failed()
+
+    def set_success(self):
+        self.status[self.service_name]['success'] = True
+        self._write()
+
+    def set_failed(self):
+        self.status[self.service_name]['success'] = False
+        self._write()
+
+    def load(self):
+        if os.path.exists(self.status_file):
+            with open(self.status_file, 'r') as report:
+                return yaml.load(report)
+
+    def _write(self):
+        with open(self.status_file, 'w') as report:
+            yaml.dump(self.status, report, default_flow_style=False)

--- a/azure_li_services/units/call.py
+++ b/azure_li_services/units/call.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.command import Command
+from azure_li_services.status_report import StatusReport
 
 
 def main():
@@ -29,6 +30,7 @@ def main():
 
     Calls a custom script in the scope of an Azure Li/Vli instance
     """
+    status = StatusReport('call')
     config = RuntimeConfig(Defaults.get_config_file())
     call_script = config.get_call_script()
 
@@ -50,5 +52,6 @@ def main():
                     )
                 ]
             )
+            status.set_success()
         finally:
             Command.run(['umount', call_source.location])

--- a/azure_li_services/units/config_lookup.py
+++ b/azure_li_services/units/config_lookup.py
@@ -23,6 +23,7 @@ from azure_li_services.command import Command
 from azure_li_services.path import Path
 from azure_li_services.exceptions import AzureHostedConfigFileNotFoundException
 from azure_li_services.defaults import Defaults
+from azure_li_services.status_report import StatusReport
 
 
 def main():
@@ -33,6 +34,7 @@ def main():
     and make it locally available at the location described by
     Defaults.get_config_file_name()
     """
+    status = StatusReport('config_lookup')
     config_type = namedtuple(
         'config_type', ['name', 'location', 'label']
     )
@@ -63,5 +65,6 @@ def main():
             ['cp', azure_config_file, Defaults.get_config_file_name()]
         )
         os.chmod(Defaults.get_config_file_name(), 0o600)
+        status.set_success()
     finally:
         Command.run(['umount', azure_config.location])

--- a/azure_li_services/units/install.py
+++ b/azure_li_services/units/install.py
@@ -23,6 +23,7 @@ from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.command import Command
 from azure_li_services.path import Path
+from azure_li_services.status_report import StatusReport
 
 
 def main():
@@ -33,6 +34,7 @@ def main():
     Installs all packages configured in the scope of an Azure
     Li/Vli instance
     """
+    status = StatusReport('install')
     config = RuntimeConfig(Defaults.get_config_file())
     packages_config = config.get_packages_config()
 
@@ -96,5 +98,6 @@ def main():
                         'install', '--auto-agree-with-licenses'
                     ] + install_items
                 )
+            status.set_success()
         finally:
             Command.run(['umount', call_source.location])

--- a/azure_li_services/units/network.py
+++ b/azure_li_services/units/network.py
@@ -20,6 +20,7 @@ from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.network import AzureHostedNetworkSetup
 from azure_li_services.instance_type import InstanceType
+from azure_li_services.status_report import StatusReport
 
 from azure_li_services.exceptions import AzureHostedNetworkConfigDataException
 
@@ -31,6 +32,7 @@ def main():
     Creates network configuration files to successfully start the
     network in the scope of an Azure Li/Vli instance
     """
+    status = StatusReport('network')
     config = RuntimeConfig(Defaults.get_config_file())
     network_config = config.get_network_config()
     instance_type = config.get_instance_type()
@@ -41,6 +43,7 @@ def main():
                 li_network.create_interface_config()
                 li_network.create_vlan_config()
                 li_network.create_default_route_config()
+            status.set_success()
         else:
             raise AzureHostedNetworkConfigDataException(
                 'No idea how to setup network for Instance Type: {0}'.format(

--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -21,6 +21,7 @@ import os
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.users import Users
+from azure_li_services.status_report import StatusReport
 
 from azure_li_services.exceptions import AzureHostedUserConfigDataException
 from azure_li_services.path import Path
@@ -33,6 +34,7 @@ def main():
     Creates the configured user and its access setup for ssh
     and sudo services in the scope of an Azure Li/Vli instance
     """
+    status = StatusReport('user')
     config = RuntimeConfig(Defaults.get_config_file())
 
     user_config = config.get_user_config()
@@ -42,6 +44,7 @@ def main():
         setup_sudo_authorization(user)
 
     setup_sudo_config()
+    status.set_success()
 
 
 def create_user(user):

--- a/test/data/some_service.report.yaml
+++ b/test/data/some_service.report.yaml
@@ -1,0 +1,2 @@
+some_service:
+  success: true

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -16,4 +16,4 @@ class TestDefaults(object):
 
     def test_get_status_report_directory(self):
         assert Defaults.get_status_report_directory() == \
-            '/etc/azure_li_services'
+            '/var/lib/azure_li_services'

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -13,3 +13,7 @@ class TestDefaults(object):
         mock_os_path_exists.return_value = False
         with raises(AzureHostedConfigFileNotFoundException):
             Defaults.get_config_file()
+
+    def test_get_status_report_directory(self):
+        assert Defaults.get_status_report_directory() == \
+            '/etc/azure_li_services'

--- a/test/unit/status_report_test.py
+++ b/test/unit/status_report_test.py
@@ -1,0 +1,52 @@
+import io
+from unittest.mock import (
+    MagicMock, patch, call
+)
+
+from azure_li_services.status_report import StatusReport
+
+
+class TestStatusReport(object):
+    @patch('os.path.exists')
+    @patch('azure_li_services.status_report.Path.create')
+    def setup(self, mock_Path_create, mock_exists):
+        mock_exists.return_value = False
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            self.report = StatusReport('some_service')
+            file_handle = mock_open.return_value.__enter__.return_value
+            mock_open.assert_called_once_with(
+                '/etc/azure_li_services/some_service.report.yaml', 'w'
+            )
+            assert file_handle.write.call_args_list == [
+                call('some_service'),
+                call(':'),
+                call('\n'),
+                call('  '),
+                call('success'),
+                call(':'),
+                call(' '),
+                call('false'),
+                call('\n')
+            ]
+
+    def test_set_success(self):
+        with patch('builtins.open', create=True) as mock_open:
+            self.report.set_success()
+            mock_open.assert_called_once_with(
+                '/etc/azure_li_services/some_service.report.yaml', 'w'
+            )
+            assert self.report.status['some_service']['success'] is True
+
+    def test_set_failed(self):
+        with patch('builtins.open', create=True) as mock_open:
+            self.report.set_failed()
+            mock_open.assert_called_once_with(
+                '/etc/azure_li_services/some_service.report.yaml', 'w'
+            )
+            assert self.report.status['some_service']['success'] is False
+
+    def test_load(self):
+        self.report.status_file = '../data/some_service.report.yaml'
+        result = self.report.load()
+        assert result['some_service']['success'] is True

--- a/test/unit/status_report_test.py
+++ b/test/unit/status_report_test.py
@@ -16,7 +16,7 @@ class TestStatusReport(object):
             self.report = StatusReport('some_service')
             file_handle = mock_open.return_value.__enter__.return_value
             mock_open.assert_called_once_with(
-                '/etc/azure_li_services/some_service.report.yaml', 'w'
+                '/var/lib/azure_li_services/some_service.report.yaml', 'w'
             )
             assert file_handle.write.call_args_list == [
                 call('some_service'),
@@ -34,7 +34,7 @@ class TestStatusReport(object):
         with patch('builtins.open', create=True) as mock_open:
             self.report.set_success()
             mock_open.assert_called_once_with(
-                '/etc/azure_li_services/some_service.report.yaml', 'w'
+                '/var/lib/azure_li_services/some_service.report.yaml', 'w'
             )
             assert self.report.status['some_service']['success'] is True
 
@@ -42,7 +42,7 @@ class TestStatusReport(object):
         with patch('builtins.open', create=True) as mock_open:
             self.report.set_failed()
             mock_open.assert_called_once_with(
-                '/etc/azure_li_services/some_service.report.yaml', 'w'
+                '/var/lib/azure_li_services/some_service.report.yaml', 'w'
             )
             assert self.report.status['some_service']['success'] is False
 

--- a/test/unit/units/call_test.py
+++ b/test/unit/units/call_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, call
+    patch, call, Mock
 )
 from azure_li_services.units.call import main
 
@@ -7,9 +7,14 @@ from azure_li_services.units.call import main
 class TestCall(object):
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.call.Defaults.get_config_file')
-    def test_main(self, mock_get_config_file, mock_Command_run):
+    @patch('azure_li_services.units.call.StatusReport')
+    def test_main(self, mock_StatusReport, mock_get_config_file, mock_Command_run):
+        status = Mock()
+        mock_StatusReport.return_value = status
         mock_get_config_file.return_value = '../data/config.yaml'
         main()
+        mock_StatusReport.assert_called_once_with('call')
+        status.set_success.assert_called_once_with()
         assert mock_Command_run.call_args_list == [
             call(['mount', '--label', 'azconfig', '/mnt']),
             call(['bash', '-c', '/mnt/path/to/executable/file']),

--- a/test/unit/units/config_lookup_test.py
+++ b/test/unit/units/config_lookup_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import (
-    patch, call
+    patch, call, Mock
 )
 from pytest import raises
 from azure_li_services.units.config_lookup import main
@@ -10,11 +10,17 @@ class TestConfigLookup(object):
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.path.Path.create')
     @patch('azure_li_services.path.Path.which')
+    @patch('azure_li_services.units.config_lookup.StatusReport')
     @patch('os.chmod')
     def test_main(
-        self, mock_chmod, mock_Path_which, mock_Path_create, mock_Command_run
+        self, mock_chmod, mock_StatusReport, mock_Path_which,
+        mock_Path_create, mock_Command_run
     ):
+        status = Mock()
+        mock_StatusReport.return_value = status
         main()
+        mock_StatusReport.assert_called_once_with('config_lookup')
+        status.set_success.assert_called_once_with()
         assert mock_Command_run.call_args_list == [
             call(['mount', '--label', 'azconfig', '/mnt']),
             call([
@@ -33,7 +39,8 @@ class TestConfigLookup(object):
 
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.path.Path.which')
-    def test_main_raises(self, mock_Path_which, mock_Command_run):
+    @patch('azure_li_services.units.config_lookup.StatusReport')
+    def test_main_raises(self, mock_StatusReport, mock_Path_which, mock_Command_run):
         mock_Path_which.return_value = None
         with raises(AzureHostedConfigFileNotFoundException):
             main()

--- a/test/unit/units/install_test.py
+++ b/test/unit/units/install_test.py
@@ -9,16 +9,21 @@ class TestInstall(object):
     @patch('azure_li_services.units.install.Defaults.get_config_file')
     @patch('azure_li_services.units.install.Path.create')
     @patch('azure_li_services.units.install.glob.iglob')
+    @patch('azure_li_services.units.install.StatusReport')
     def test_main(
-        self, mock_iglob, mock_Path_create, mock_get_config_file,
-        mock_Command_run
+        self, mock_StatusReport, mock_iglob, mock_Path_create,
+        mock_get_config_file, mock_Command_run
     ):
+        status = Mock()
+        mock_StatusReport.return_value = status
         command_result = Mock()
         command_result.output = 'foo'
         mock_Command_run.return_value = command_result
         mock_iglob.return_value = ['/var/lib/localrepos/azure_packages/foo.rpm']
         mock_get_config_file.return_value = '../data/config.yaml'
         main()
+        mock_StatusReport.assert_called_once_with('install')
+        status.set_success.assert_called_once_with()
         mock_Path_create.assert_called_once_with(
             '/var/lib/localrepos/azure_packages'
         )

--- a/test/unit/units/network_test.py
+++ b/test/unit/units/network_test.py
@@ -9,19 +9,26 @@ from azure_li_services.exceptions import AzureHostedNetworkConfigDataException
 class TestNetwork(object):
     @patch('azure_li_services.units.network.AzureHostedNetworkSetup')
     @patch('azure_li_services.units.network.Defaults.get_config_file')
+    @patch('azure_li_services.units.network.StatusReport')
     def test_main_li_network(
-        self, mock_get_config_file, mock_AzureHostedNetworkSetup
+        self, mock_StatusReport, mock_get_config_file,
+        mock_AzureHostedNetworkSetup
     ):
+        status = Mock()
+        mock_StatusReport.return_value = status
         li_network = Mock()
         mock_AzureHostedNetworkSetup.return_value = li_network
         mock_get_config_file.return_value = '../data/config.yaml'
         main()
+        mock_StatusReport.assert_called_once_with('network')
+        status.set_success.assert_called_once_with()
         li_network.create_interface_config.assert_called_once_with()
         li_network.create_vlan_config.assert_called_once_with()
         li_network.create_default_route_config.assert_called_once_with()
 
     @patch('azure_li_services.units.network.Defaults.get_config_file')
-    def test_main_vli_network(self, mock_get_config_file):
+    @patch('azure_li_services.units.network.StatusReport')
+    def test_main_vli_network(self, mock_StatusReport, mock_get_config_file):
         mock_get_config_file.return_value = '../data/config_vli.yaml'
         with raises(AzureHostedNetworkConfigDataException):
             main()


### PR DESCRIPTION
In preperation to operate on an overall success or failed
state depending on the result of the individual services,
each service should have an easy way to report its result
state. The StatusReport class implements this in a way
that each service reports its state in a yaml file written
to the directory provided by get_status_report_directory().
As services are called by systemd and will run in parallel,
one file per service name is created to avoid potential
I/O conflicts on write. Issue #19