### PR TITLE
Handle missing packages source as error

### DIFF
--- a/azure_li_services/exceptions.py
+++ b/azure_li_services/exceptions.py
@@ -66,3 +66,10 @@ class AzureHostedUserConfigDataException(AzureHostedException):
     Exception raised if any of the required data to setup the user
     is missing
     """
+
+
+class AzureHostedInstallException(AzureHostedException):
+    """
+    Exception raised if any of the required data to install
+    packages is missing
+    """

--- a/azure_li_services/units/install.py
+++ b/azure_li_services/units/install.py
@@ -24,6 +24,8 @@ from azure_li_services.defaults import Defaults
 from azure_li_services.command import Command
 from azure_li_services.path import Path
 
+from azure_li_services.exceptions import AzureHostedInstallException
+
 
 def main():
     """
@@ -43,7 +45,12 @@ def main():
         location='/mnt', label='azconfig'
     )
 
-    if 'directory' in packages_config:
+    if packages_config:
+        if 'directory' not in packages_config:
+            raise AzureHostedInstallException(
+                'directory list missing in config {0}'.format(packages_config)
+            )
+
         Command.run(
             ['mount', '--label', call_source.label, call_source.location]
         )

--- a/test/unit/units/install_test.py
+++ b/test/unit/units/install_test.py
@@ -1,7 +1,9 @@
+from pytest import raises
 from unittest.mock import (
     patch, call, Mock
 )
 from azure_li_services.units.install import main
+from azure_li_services.exceptions import AzureHostedInstallException
 
 
 class TestInstall(object):
@@ -56,3 +58,12 @@ class TestInstall(object):
             ),
             call(['umount', '/mnt'])
         ]
+
+    @patch('azure_li_services.units.install.Defaults.get_config_file')
+    @patch('azure_li_services.units.install.RuntimeConfig')
+    def test_main_raises(self, mock_RuntimeConfig, mock_get_config_file):
+        config = Mock()
+        mock_RuntimeConfig.return_value = config
+        config.get_packages_config.return_value = {'packages': None}
+        with raises(AzureHostedInstallException):
+            main()


### PR DESCRIPTION
The install service did not handle an empty list of packages
sources as an error and just proceeded without installing
packages. However in the scope of the large instance setup
it is expected that there are packages to install and if
not this is an error condition. This Fixes #26