### PR TITLE
Fixup user service for handling existing users

### DIFF
--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -39,7 +39,7 @@ def main():
 
     user_config = config.get_user_config()
     for user in user_config:
-        create_user(user)
+        create_or_modify_user(user)
         setup_ssh_authorization(user)
         setup_sudo_authorization(user)
 
@@ -47,7 +47,7 @@ def main():
     status.set_success()
 
 
-def create_user(user):
+def create_or_modify_user(user):
     if 'username' not in user:
         raise AzureHostedUserConfigDataException(
             'username missing in config {0}'.format(user)


### PR DESCRIPTION
If the user setup in the config file already exists on the
system, the user service failed to add that user as it
should rather modify it. This Fixes #25