### PR TITLE
Added DVD fallback mounting sequence

### DIFF
--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -16,7 +16,9 @@
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+from collections import namedtuple
 
+from azure_li_services.command import Command
 from azure_li_services.exceptions import AzureHostedConfigFileNotFoundException
 
 
@@ -51,3 +53,22 @@ class Defaults(object):
             raise AzureHostedConfigFileNotFoundException(
                 'No Azure Li/VLi file found: {0}'.format(config_file)
             )
+
+    @classmethod
+    def mount_config_source(self):
+        config_type = namedtuple(
+            'config_type', ['name', 'location', 'label']
+        )
+        azure_config = config_type(
+            name=os.path.basename(Defaults.get_config_file_name()),
+            location='/mnt', label='azconfig'
+        )
+        try:
+            Command.run(
+                ['mount', '--label', azure_config.label, azure_config.location]
+            )
+        except Exception:
+            Command.run(
+                ['mount', '/dev/dvd', azure_config.location]
+            )
+        return azure_config

--- a/azure_li_services/exceptions.py
+++ b/azure_li_services/exceptions.py
@@ -45,6 +45,14 @@ class AzureHostedConfigDataException(AzureHostedException):
     """
 
 
+class AzureHostedConfigFileSourceMountException(AzureHostedException):
+    """
+    Exception raised if none of the methods to mount the external
+    source location which contains the Azure Li/VLi config file
+    were successful
+    """
+
+
 class AzureHostedCommandException(AzureHostedException):
     """
     Exception raised if an external command called via a Command

--- a/azure_li_services/units/call.py
+++ b/azure_li_services/units/call.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
-from collections import namedtuple
-
 # project
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
@@ -34,16 +32,8 @@ def main():
     config = RuntimeConfig(Defaults.get_config_file())
     call_script = config.get_call_script()
 
-    source_type = namedtuple(
-        'source_type', ['location', 'label']
-    )
-    call_source = source_type(
-        location='/mnt', label='azconfig'
-    )
     if call_script:
-        Command.run(
-            ['mount', '--label', call_source.label, call_source.location]
-        )
+        call_source = Defaults.mount_config_source()
         try:
             Command.run(
                 [

--- a/azure_li_services/units/config_lookup.py
+++ b/azure_li_services/units/config_lookup.py
@@ -16,7 +16,6 @@
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-from collections import namedtuple
 
 # project
 from azure_li_services.command import Command
@@ -35,17 +34,7 @@ def main():
     Defaults.get_config_file_name()
     """
     status = StatusReport('config_lookup')
-    config_type = namedtuple(
-        'config_type', ['name', 'location', 'label']
-    )
-    azure_config = config_type(
-        name=os.path.basename(Defaults.get_config_file_name()),
-        location='/mnt', label='azconfig'
-    )
-
-    Command.run(
-        ['mount', '--label', azure_config.label, azure_config.location]
-    )
+    azure_config = Defaults.mount_config_source()
 
     try:
         azure_config_lookup_paths = [azure_config.location]

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,4 +1,6 @@
-from unittest.mock import patch
+from unittest.mock import (
+    patch, call
+)
 from pytest import raises
 
 from azure_li_services.defaults import Defaults
@@ -17,3 +19,18 @@ class TestDefaults(object):
     def test_get_status_report_directory(self):
         assert Defaults.get_status_report_directory() == \
             '/var/lib/azure_li_services'
+
+    @patch('azure_li_services.defaults.Command.run')
+    def test_mount_config_source_fallback(self, mock_Command_run):
+        command_result = [True, False]
+
+        def side_effect(self):
+            if not command_result.pop():
+                raise Exception
+
+        mock_Command_run.side_effect = side_effect
+        Defaults.mount_config_source()
+        assert mock_Command_run.call_args_list == [
+            call(['mount', '--label', 'azconfig', '/mnt']),
+            call(['mount', '/dev/dvd', '/mnt'])
+        ]

--- a/test/unit/units/call_test.py
+++ b/test/unit/units/call_test.py
@@ -8,7 +8,11 @@ class TestCall(object):
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.call.Defaults.get_config_file')
     @patch('azure_li_services.units.call.StatusReport')
-    def test_main(self, mock_StatusReport, mock_get_config_file, mock_Command_run):
+    @patch('azure_li_services.defaults.Defaults.mount_config_source')
+    def test_main(
+        self, mock_mount_config_source, mock_StatusReport,
+        mock_get_config_file, mock_Command_run
+    ):
         status = Mock()
         mock_StatusReport.return_value = status
         mock_get_config_file.return_value = '../data/config.yaml'
@@ -16,7 +20,14 @@ class TestCall(object):
         mock_StatusReport.assert_called_once_with('call')
         status.set_success.assert_called_once_with()
         assert mock_Command_run.call_args_list == [
-            call(['mount', '--label', 'azconfig', '/mnt']),
-            call(['bash', '-c', '/mnt/path/to/executable/file']),
-            call(['umount', '/mnt'])
+            call(
+                [
+                    'bash', '-c', '{0}/path/to/executable/file'.format(
+                        mock_mount_config_source.return_value.location
+                    )
+                ]
+            ),
+            call(
+                ['umount', mock_mount_config_source.return_value.location]
+            )
         ]

--- a/test/unit/units/config_lookup_test.py
+++ b/test/unit/units/config_lookup_test.py
@@ -11,10 +11,11 @@ class TestConfigLookup(object):
     @patch('azure_li_services.path.Path.create')
     @patch('azure_li_services.path.Path.which')
     @patch('azure_li_services.units.config_lookup.StatusReport')
+    @patch('azure_li_services.defaults.Defaults.mount_config_source')
     @patch('os.chmod')
     def test_main(
-        self, mock_chmod, mock_StatusReport, mock_Path_which,
-        mock_Path_create, mock_Command_run
+        self, mock_chmod, mock_mount_config_source, mock_StatusReport,
+        mock_Path_which, mock_Path_create, mock_Command_run
     ):
         status = Mock()
         mock_StatusReport.return_value = status
@@ -22,25 +23,29 @@ class TestConfigLookup(object):
         mock_StatusReport.assert_called_once_with('config_lookup')
         status.set_success.assert_called_once_with()
         assert mock_Command_run.call_args_list == [
-            call(['mount', '--label', 'azconfig', '/mnt']),
             call([
                 'cp', mock_Path_which.return_value,
                 '/etc/suse_firstboot_config.yaml'
             ]),
-            call(['umount', '/mnt'])
+            call(['umount', mock_mount_config_source.return_value.location])
         ]
         mock_chmod.assert_called_once_with(
             '/etc/suse_firstboot_config.yaml', 0o600
         )
         mock_Path_create.assert_called_once_with('/etc')
         mock_Path_which.assert_called_once_with(
-            'suse_firstboot_config.yaml', ['/mnt']
+            mock_mount_config_source.return_value.name,
+            [mock_mount_config_source.return_value.location]
         )
 
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.path.Path.which')
     @patch('azure_li_services.units.config_lookup.StatusReport')
-    def test_main_raises(self, mock_StatusReport, mock_Path_which, mock_Command_run):
+    @patch('azure_li_services.defaults.Defaults.mount_config_source')
+    def test_main_raises(
+        self, mock_mount_config_source, mock_StatusReport,
+        mock_Path_which, mock_Command_run
+    ):
         mock_Path_which.return_value = None
         with raises(AzureHostedConfigFileNotFoundException):
             main()


### PR DESCRIPTION
Primarily we mount a LUN by label, but if that failed a
fallback mount from /dev/dvd kicks in. Only if that fails
the overall mount attempt has failed. This Fixes #13