### PR TITLE
Fixup ssh files ownership in user service

### DIFF
--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -35,6 +35,10 @@ credentials:
     id: 495
     group: nogroup
     home_dir: /var/lib/empty
+  -
+    username: root
+    shadow_hash: "sha-512-cipher"
+    ssh-key: "ssh-rsa foo"
 
 packages:
   repository_name: azure_packages

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -51,6 +51,11 @@ class TestRuntimeConfig(object):
                 'home_dir': '/var/lib/empty',
                 'username': 'rpc',
                 'id': 495
+            },
+            {
+                'ssh-key': 'ssh-rsa foo',
+                'username': 'root',
+                'shadow_hash': 'sha-512-cipher'
             }
         ]
 


### PR DESCRIPTION
ssh files must be owned by the user they belong to. In addition
the home path of the root user is not located in the standard
home directory of users and needs an extra handling. This
Fixes #37