### PR TITLE
Allow import of private key

### DIFF
--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -108,6 +108,20 @@ schema = {
                     'required': False,
                     'type': 'string'
                 },
+                'ssh-private-key': {
+                    'required': False,
+                    'type': 'dict',
+                    'schema': {
+                        'name': {
+                            'required': True,
+                            'type': 'string'
+                        },
+                        'key': {
+                            'required': True,
+                            'type': 'string'
+                        }
+                    }
+                },
                 'id': {
                     'required': False,
                     'type': 'number'

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -31,6 +31,9 @@ credentials:
     username: hanauser
     shadow_hash: "sha-512-cipher"
     ssh-key: "ssh-rsa foo"
+    ssh-private-key:
+        name: "id_rsa"
+        key: "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpYWFhYCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg=="
   -
     username: rpc
     id: 495

--- a/test/data/ssh-fake-pkey
+++ b/test/data/ssh-fake-pkey
@@ -1,0 +1,3 @@
+-----BEGIN RSA PRIVATE KEY-----
+XXXX
+-----END RSA PRIVATE KEY-----

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -44,7 +44,12 @@ class TestRuntimeConfig(object):
             {
                 'ssh-key': 'ssh-rsa foo',
                 'username': 'hanauser',
-                'shadow_hash': 'sha-512-cipher'
+                'shadow_hash': 'sha-512-cipher',
+                'ssh-private-key': {
+                    'name': 'id_rsa',
+                    'key': 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0'
+                    'tLQpYWFhYCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg=='
+                }
             },
             {
                 'group': 'nogroup',

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -77,12 +77,18 @@ class TestUser(object):
             ]
             assert mock_open.call_args_list == [
                 call('/home/hanauser/.ssh/authorized_keys', 'a'),
+                call('/home/hanauser/.ssh/id_rsa', 'w'),
                 call('/root/.ssh/authorized_keys', 'a'),
                 call('/etc/sudoers', 'a')
             ]
             assert file_handle.write.call_args_list == [
                 call('\n'),
                 call('ssh-rsa foo'),
+                call(
+                    b'-----BEGIN RSA PRIVATE KEY-----\n'
+                    b'XXXX\n'
+                    b'-----END RSA PRIVATE KEY-----\n'
+                ),
                 call('\n'),
                 call('ssh-rsa foo'),
                 call('\n'),
@@ -91,6 +97,7 @@ class TestUser(object):
             assert mock_chmod.call_args_list == [
                 call('/home/hanauser/.ssh/', 0o700),
                 call('/home/hanauser/.ssh/authorized_keys', 0o600),
+                call('/home/hanauser/.ssh/id_rsa', 0o600),
                 call('/root/.ssh/', 0o700),
                 call('/root/.ssh/authorized_keys', 0o600)
             ]
@@ -102,6 +109,11 @@ class TestUser(object):
                 ),
                 call(
                     '/home/hanauser/.ssh/authorized_keys',
+                    mock_getpwnam.return_value.pw_uid,
+                    mock_getgrnam.return_value.gr_gid
+                ),
+                call(
+                    '/home/hanauser/.ssh/id_rsa',
                     mock_getpwnam.return_value.pw_uid,
                     mock_getgrnam.return_value.gr_gid
                 )


### PR DESCRIPTION
Add an additional optional sub section named ssh-private-key
into the credentials section. The section allows for a name
which is the base filename of an ssh private key and the key
value encoded as base64 string. This Fixes #42