### PR TITLE
Fix service order for storage unit

### DIFF
--- a/systemd/azure-li-storage.service
+++ b/systemd/azure-li-storage.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Setup of Azure Li/VLi Storage Mountpoints
 ConditionPathExists=/.azure-li-storage.trigger
-After=azure-li-config-lookup.service azure-li-network.service
+After=azure-li-config-lookup.service azure-li-network.service network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The storage service has to run after the network target
has been reached. This Fixes #49