### PR TITLE
Added kernel crash dump setup

### DIFF
--- a/azure_li_services/runtime_config.py
+++ b/azure_li_services/runtime_config.py
@@ -121,6 +121,14 @@ class RuntimeConfig(object):
         if self.config_data:
             return self.config_data.get('hostname')
 
+    def get_crash_kernel_high(self):
+        if self.config_data:
+            return self.config_data.get('crash_kernel_high')
+
+    def get_crash_kernel_low(self):
+        if self.config_data:
+            return self.config_data.get('crash_kernel_low')
+
     def get_network_config(self):
         if self.config_data:
             return self.config_data.get('networking')

--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -17,6 +17,14 @@ schema = {
         'required': False,
         'type': 'string'
     },
+    'crash_kernel_high': {
+        'required': False,
+        'type': 'number'
+    },
+    'crash_kernel_low': {
+        'required': False,
+        'type': 'number'
+    },
     'machine_constraints': {
         'required': False,
         'type': 'dict',

--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -37,6 +37,9 @@ def main():
     if hostname:
         set_hostname(hostname)
 
+    set_kdump_service(
+        config.get_crash_kernel_high(), config.get_crash_kernel_low()
+    )
     set_kernel_samepage_merging_mode()
     set_energy_performance_settings()
 
@@ -69,6 +72,53 @@ def set_energy_performance_settings():
     for cpupower_call in cpupower_calls:
         Command.run(cpupower_call)
     _write_boot_local(cpupower_calls)
+
+
+def set_kdump_service(high, low):
+    calibrated = _kdump_calibrate()
+    grub_defaults = '/etc/default/grub'
+    Command.run(
+        [
+            'sed', '-ie',
+            's@crashkernel=[0-9]\+M,low@crashkernel={0}M,low@'.format(
+                low or calibrated['Low']
+            ),
+            grub_defaults
+        ]
+    )
+    Command.run(
+        [
+            'sed', '-ie',
+            's@crashkernel=[0-9]\+M,high@crashkernel={0}M,high@'.format(
+                high or calibrated['High']
+            ),
+            grub_defaults
+        ]
+    )
+    Command.run(
+        ['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg']
+    )
+    Command.run(
+        ['systemctl', 'restart', 'kdump']
+    )
+
+
+def _kdump_calibrate():
+    kdumptool_call = Command.run(
+        ['kdumptool', 'calibrate']
+    )
+    calibration_values = {
+        'Low': 80,
+        'High': 160
+    }
+    for setting in kdumptool_call.output.split(os.linesep):
+        try:
+            (key, value) = setting.split(':')
+        except Exception:
+            # ignore setting not in key:value format
+            pass
+        calibration_values[key] = int(value)
+    return calibration_values
 
 
 def _write_boot_local(entries):

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -2,6 +2,8 @@ version: "20180614"
 instance_type: LargeInstance
 sku: "SR92"
 hostname: "azure"
+crash_kernel_low: 80
+crash_kernel_high: 160
 
 machine_constraints:
   min_cores: 32

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -96,3 +96,9 @@ class TestRuntimeConfig(object):
 
     def test_get_hostname(self):
         assert self.runtime_config.get_hostname() == 'azure'
+
+    def test_get_crash_kernel_high(self):
+        assert self.runtime_config.get_crash_kernel_high() == 160
+
+    def test_get_crash_kernel_low(self):
+        assert self.runtime_config.get_crash_kernel_low() == 80

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -1,50 +1,122 @@
 import io
+import os
+from textwrap import dedent
 from unittest.mock import (
     patch, Mock, MagicMock, call
 )
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.units.system_setup import main
 
+import azure_li_services.units.system_setup as system_setup
+
 
 class TestSystemSetup(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
-    @patch('os.chmod')
-    @patch('azure_li_services.command.Command.run')
-    @patch('azure_li_services.units.system_setup.Defaults.get_config_file')
-    @patch('azure_li_services.units.system_setup.RuntimeConfig')
-    @patch('azure_li_services.units.system_setup.StatusReport')
+    @patch.object(system_setup, 'set_hostname')
+    @patch.object(system_setup, 'set_kdump_service')
+    @patch.object(system_setup, 'set_kernel_samepage_merging_mode')
+    @patch.object(system_setup, 'set_energy_performance_settings')
+    @patch.object(system_setup.Defaults, 'get_config_file')
+    @patch.object(system_setup, 'RuntimeConfig')
+    @patch.object(system_setup, 'StatusReport')
     def test_main(
         self, mock_StatusReport, mock_RuntimConfig, mock_get_config_file,
-        mock_Command_run, mock_os_chmod
+        mock_set_energy_performance_settings,
+        mock_set_kernel_samepage_merging_mode,
+        mock_set_kdump_service, mock_set_hostname
     ):
         status = Mock()
         mock_StatusReport.return_value = status
         mock_RuntimConfig.return_value = self.config
+        main()
+        mock_set_hostname.assert_called_once_with('azure')
+        mock_set_kdump_service.assert_called_once_with(160, 80)
+        mock_set_kernel_samepage_merging_mode.assert_called_once_with()
+        mock_set_energy_performance_settings.assert_called_once_with()
+        mock_StatusReport.assert_called_once_with('system_setup')
+        status.set_success.assert_called_once_with()
+
+    @patch('azure_li_services.command.Command.run')
+    def test_set_hostname(self, mock_Command_run):
+        system_setup.set_hostname('azure')
+        mock_Command_run.assert_called_once_with(
+            ['hostnamectl', 'set-hostname', 'azure']
+        )
+
+    @patch('os.chmod')
+    def test_set_kernel_samepage_merging_mode(self, mock_os_chmod):
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value
-            main()
-            mock_StatusReport.assert_called_once_with('system_setup')
-            status.set_success.assert_called_once_with()
+            system_setup.set_kernel_samepage_merging_mode()
             assert mock_open.call_args_list == [
                 call('/sys/kernel/mm/ksm/run', 'w'),
-                call('/etc/init.d/boot.local', 'a'),
                 call('/etc/init.d/boot.local', 'a')
             ]
             assert file_handle.write.call_args_list == [
                 call('0\n'),
                 call('echo 0 > /sys/kernel/mm/ksm/run\n'),
+            ]
+            mock_os_chmod.assert_called_once_with(
+                '/etc/init.d/boot.local', 0o755
+            )
+
+    @patch('os.chmod')
+    @patch('azure_li_services.command.Command.run')
+    def test_set_energy_performance_settings(
+        self, mock_Command_run, mock_os_chmod
+    ):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            system_setup.set_energy_performance_settings()
+            mock_open.assert_called_once_with(
+                '/etc/init.d/boot.local', 'a'
+            )
+            assert file_handle.write.call_args_list == [
                 call('cpupower frequency-set -g performance\n'),
                 call('cpupower set -b 0\n')
             ]
             assert mock_Command_run.call_args_list == [
-                call(['hostnamectl', 'set-hostname', 'azure']),
                 call(['cpupower', 'frequency-set', '-g', 'performance']),
                 call(['cpupower', 'set', '-b', '0'])
             ]
-            assert mock_os_chmod.call_args_list == [
-                call('/etc/init.d/boot.local', 0o755),
-                call('/etc/init.d/boot.local', 0o755)
-            ]
+            mock_os_chmod.assert_called_once_with(
+                '/etc/init.d/boot.local', 0o755
+            )
+
+    @patch('azure_li_services.command.Command.run')
+    def test_set_kdump_service(self, mock_Command_run):
+        kdumptool_call = Mock()
+        kdumptool_call.output = dedent('''
+            Total: 16308
+            Low: 72
+            High: 123
+            MinLow: 72
+            MaxLow: 2455
+            MinHigh: 0
+            MaxHigh: 13824
+        ''').strip() + os.linesep
+        mock_Command_run.return_value = kdumptool_call
+        system_setup.set_kdump_service(None, None)
+        assert mock_Command_run.call_args_list == [
+            call(['kdumptool', 'calibrate']),
+            call(
+                [
+                    'sed', '-ie',
+                    's@crashkernel=[0-9]\\+M,low@crashkernel=72M,low@',
+                    '/etc/default/grub'
+                ]
+            ),
+            call(
+                [
+                    'sed', '-ie',
+                    's@crashkernel=[0-9]\\+M,high@crashkernel=123M,high@',
+                    '/etc/default/grub'
+                ]
+            ),
+            call(['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg']),
+            call(['systemctl', 'restart', 'kdump'])
+        ]


### PR DESCRIPTION
Allows the setup of custom kernel crash dump values from the
yaml config file. If not specified the kdumptool calibration
results will be used to setup the high and low memory range to
store crash dumps. Please also note that the image comes with
a pre-configured crashdump setup in case the kernel crashes
before this system_setup service has done its job.
This Fixes #50