### PR TITLE
Setup start of saptune daemon and tuned service

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -42,6 +42,7 @@ def main():
     )
     set_kernel_samepage_merging_mode()
     set_energy_performance_settings()
+    set_saptune_service()
 
     status.set_success()
 
@@ -72,6 +73,24 @@ def set_energy_performance_settings():
     for cpupower_call in cpupower_calls:
         Command.run(cpupower_call)
     _write_boot_local(cpupower_calls)
+
+
+def set_saptune_service():
+    Command.run(
+        ['saptune', 'daemon', 'start']
+    )
+    Command.run(
+        ['saptune', 'solution', 'apply', 'HANA']
+    )
+    Command.run(
+        ['tuned-adm', 'profile', 'sap-hana']
+    )
+    Command.run(
+        ['systemctl', 'enable', 'tuned']
+    )
+    Command.run(
+        ['systemctl', 'start', 'tuned']
+    )
 
 
 def set_kdump_service(high, low):

--- a/systemd/azure-li-system-setup.service
+++ b/systemd/azure-li-system-setup.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=System Setup of Azure Li/VLi machine
 ConditionPathExists=/.azure-li-system-setup.trigger
-After=azure-li-config-lookup.service systemd-hostnamed.service
+After=azure-li-config-lookup.service azure-li-install.service systemd-hostnamed.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The start of the service requires the sap-hana profile
to be installed on the system. The hana profile as of
today is delivered by a custom package from $MS, installed
via the azure-li-install service. Thus the system_setup
service now runs after the install service.
This Fixes #52