### PR TITLE
Added reboot intervention on Very Large Instances

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -19,6 +19,7 @@ import os
 
 # project
 from azure_li_services.runtime_config import RuntimeConfig
+from azure_li_services.instance_type import InstanceType
 from azure_li_services.defaults import Defaults
 from azure_li_services.command import Command
 from azure_li_services.status_report import StatusReport
@@ -33,6 +34,7 @@ def main():
     status = StatusReport('system_setup')
     config = RuntimeConfig(Defaults.get_config_file())
     hostname = config.get_hostname()
+    instance_type = config.get_instance_type()
 
     if hostname:
         set_hostname(hostname)
@@ -43,6 +45,9 @@ def main():
     set_kernel_samepage_merging_mode()
     set_energy_performance_settings()
     set_saptune_service()
+
+    if instance_type == InstanceType.vli:
+        set_reboot_intervention()
 
     status.set_success()
 
@@ -91,6 +96,15 @@ def set_saptune_service():
     Command.run(
         ['systemctl', 'start', 'tuned']
     )
+
+
+def set_reboot_intervention():
+    efi_boot_dir = '/boot/efi/'
+    if os.path.exists(efi_boot_dir):
+        with open(efi_boot_dir + 'startup.nsh', 'w') as efi_startup:
+            efi_startup.write(
+                'fs0:\efi\sles_sap\grubx64.efi{0}'.format(os.linesep)
+            )
 
 
 def set_kdump_service(high, low):


### PR DESCRIPTION
For Very Large Instance platforms the reboot may not happen
without operator intervention. On EFI systems this can be
done by an efi call script: startup.nsh. This method was
preferred over setting a BIOS boot option through the Bios
menu by the Microsoft ops team. This Fixes #46