### PR TITLE
Fixup runtime order of report service

### DIFF
--- a/systemd/azure-li-report.service
+++ b/systemd/azure-li-report.service
@@ -2,7 +2,7 @@
 Description=Report status of Azure Li/VLi services
 ConditionPathExists=/.azure-li-report.trigger
 After=azure-li-config-lookup.service azure-li-call.service azure-li-install.service azure-li-network.service azure-li-user.service azure-li-machine-constraints.service azure-li-storage.service azure-li-system-setup.service
-Before=getty.target azure-li-cleanup.service
+Before=systemd-user-sessions.service azure-li-cleanup.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Next try to make sure the report service runs before
any getty@.service is called. The getty@.service is
configured to run after systemd-user-sessions.service
Thus we should be safe if the reporting service runs
before systemd-user-sessions.service