### PR TITLE
Refactor reading of ssh private key

### DIFF
--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -118,17 +118,7 @@ schema = {
                 },
                 'ssh-private-key': {
                     'required': False,
-                    'type': 'dict',
-                    'schema': {
-                        'name': {
-                            'required': True,
-                            'type': 'string'
-                        },
-                        'key': {
-                            'required': True,
-                            'type': 'string'
-                        }
-                    }
+                    'type': 'string'
                 },
                 'id': {
                     'required': False,

--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -123,14 +123,18 @@ def setup_ssh_authorization(user):
         if 'ssh-private-key' in user:
             try:
                 ssh_key_source = Defaults.mount_config_source()
-                private_key = user['ssh-private-key']
-                ssh_key_file = ssh_auth_dir + private_key['name']
+                private_key_file = user['ssh-private-key']
                 Command.run(
                     [
                         'cp', os.sep.join(
-                            [ssh_key_source.location, private_key.get('key')]
-                        ), ssh_key_file
+                            [ssh_key_source.location, private_key_file]
+                        ), ssh_auth_dir
                     ]
+                )
+                ssh_key_file = os.path.normpath(
+                    os.sep.join(
+                        [ssh_auth_dir, os.path.basename(private_key_file)]
+                    )
                 )
                 os.chmod(ssh_key_file, 0o600)
                 if user['username'] != 'root':

--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -18,7 +18,6 @@
 import os
 import pwd
 import grp
-import base64
 
 # project
 from azure_li_services.runtime_config import RuntimeConfig
@@ -28,6 +27,7 @@ from azure_li_services.status_report import StatusReport
 
 from azure_li_services.exceptions import AzureHostedUserConfigDataException
 from azure_li_services.path import Path
+from azure_li_services.command import Command
 
 
 def main():
@@ -121,15 +121,22 @@ def setup_ssh_authorization(user):
             if user['username'] != 'root':
                 os.chown(ssh_auth_file, uid, gid)
         if 'ssh-private-key' in user:
-            private_key = user['ssh-private-key']
-            ssh_key_file = ssh_auth_dir + private_key['name']
-            with open(ssh_key_file, 'w') as ssh_private_key:
-                ssh_private_key.write(
-                    base64.b64decode(private_key['key'])
+            try:
+                ssh_key_source = Defaults.mount_config_source()
+                private_key = user['ssh-private-key']
+                ssh_key_file = ssh_auth_dir + private_key['name']
+                Command.run(
+                    [
+                        'cp', os.sep.join(
+                            [ssh_key_source.location, private_key.get('key')]
+                        ), ssh_key_file
+                    ]
                 )
-            os.chmod(ssh_key_file, 0o600)
-            if user['username'] != 'root':
-                os.chown(ssh_key_file, uid, gid)
+                os.chmod(ssh_key_file, 0o600)
+                if user['username'] != 'root':
+                    os.chown(ssh_key_file, uid, gid)
+            finally:
+                Command.run(['umount', ssh_key_source.location])
 
 
 def setup_sudo_authorization(user):

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -35,7 +35,7 @@ credentials:
     ssh-key: "ssh-rsa foo"
     ssh-private-key:
         name: "id_rsa"
-        key: "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpYWFhYCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg=="
+        key: "path/to/private/key"
   -
     username: rpc
     id: 495

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -33,9 +33,7 @@ credentials:
     username: hanauser
     shadow_hash: "sha-512-cipher"
     ssh-key: "ssh-rsa foo"
-    ssh-private-key:
-        name: "id_rsa"
-        key: "path/to/private/key"
+    ssh-private-key: "path/to/private/key/id_dsa"
   -
     username: rpc
     id: 495

--- a/test/data/ssh-fake-pkey
+++ b/test/data/ssh-fake-pkey
@@ -1,3 +1,0 @@
------BEGIN RSA PRIVATE KEY-----
-XXXX
------END RSA PRIVATE KEY-----

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -45,10 +45,7 @@ class TestRuntimeConfig(object):
                 'ssh-key': 'ssh-rsa foo',
                 'username': 'hanauser',
                 'shadow_hash': 'sha-512-cipher',
-                'ssh-private-key': {
-                    'name': 'id_rsa',
-                    'key': 'path/to/private/key'
-                }
+                'ssh-private-key': 'path/to/private/key/id_dsa'
             },
             {
                 'group': 'nogroup',

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -47,8 +47,7 @@ class TestRuntimeConfig(object):
                 'shadow_hash': 'sha-512-cipher',
                 'ssh-private-key': {
                     'name': 'id_rsa',
-                    'key': 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0'
-                    'tLQpYWFhYCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg=='
+                    'key': 'path/to/private/key'
                 }
             },
             {

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -97,8 +97,8 @@ class TestUser(object):
             assert mock_Command_run.call_args_list == [
                 call(
                     [
-                        'cp', 'config_mount/path/to/private/key',
-                        '/home/hanauser/.ssh/id_rsa'
+                        'cp', 'config_mount/path/to/private/key/id_dsa',
+                        '/home/hanauser/.ssh/'
                     ]
                 ),
                 call(['umount', 'config_mount'])
@@ -106,7 +106,7 @@ class TestUser(object):
             assert mock_chmod.call_args_list == [
                 call('/home/hanauser/.ssh/', 0o700),
                 call('/home/hanauser/.ssh/authorized_keys', 0o600),
-                call('/home/hanauser/.ssh/id_rsa', 0o600),
+                call('/home/hanauser/.ssh/id_dsa', 0o600),
                 call('/root/.ssh/', 0o700),
                 call('/root/.ssh/authorized_keys', 0o600)
             ]
@@ -122,7 +122,7 @@ class TestUser(object):
                     mock_getgrnam.return_value.gr_gid
                 ),
                 call(
-                    '/home/hanauser/.ssh/id_rsa',
+                    '/home/hanauser/.ssh/id_dsa',
                     mock_getpwnam.return_value.pw_uid,
                     mock_getgrnam.return_value.gr_gid
                 )

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -11,6 +11,8 @@ class TestUser(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
+    @patch('azure_li_services.units.user.Command.run')
+    @patch('azure_li_services.defaults.Defaults.mount_config_source')
     @patch('azure_li_services.units.user.Defaults.get_config_file')
     @patch('azure_li_services.units.user.RuntimeConfig')
     @patch('azure_li_services.units.user.Users')
@@ -24,7 +26,9 @@ class TestUser(object):
     def test_main(
         self, mock_getgrnam, mock_getpwnam, mock_chown, mock_chmod,
         mock_path_exists, mock_StatusReport, mock_Path_create,
-        mock_Users, mock_RuntimConfig, mock_get_config_file
+        mock_Users, mock_RuntimConfig, mock_get_config_file,
+        mock_mount_config_source,
+        mock_Command_run
     ):
         group_exists = [True, False, False]
         user_exists = [True, True, False]
@@ -39,12 +43,14 @@ class TestUser(object):
         mock_StatusReport.return_value = status
         mock_path_exists.return_value = True
         mock_RuntimConfig.return_value = self.config
+        mock_mount_config_source.return_value.location = 'config_mount'
         with patch('builtins.open', create=True) as mock_open:
             system_users = Mock()
             system_users.group_exists.side_effect = side_effect_group_exists
             system_users.user_exists.side_effect = side_effect_user_exists
             mock_Users.return_value = system_users
             main()
+            mock_mount_config_source.assert_called_once_with()
             mock_StatusReport.assert_called_once_with('user')
             status.set_success.assert_called_once_with()
             file_handle = mock_open.return_value.__enter__.return_value
@@ -77,22 +83,25 @@ class TestUser(object):
             ]
             assert mock_open.call_args_list == [
                 call('/home/hanauser/.ssh/authorized_keys', 'a'),
-                call('/home/hanauser/.ssh/id_rsa', 'w'),
                 call('/root/.ssh/authorized_keys', 'a'),
                 call('/etc/sudoers', 'a')
             ]
             assert file_handle.write.call_args_list == [
                 call('\n'),
                 call('ssh-rsa foo'),
-                call(
-                    b'-----BEGIN RSA PRIVATE KEY-----\n'
-                    b'XXXX\n'
-                    b'-----END RSA PRIVATE KEY-----\n'
-                ),
                 call('\n'),
                 call('ssh-rsa foo'),
                 call('\n'),
                 call('%admin ALL=(ALL) NOPASSWD: ALL')
+            ]
+            assert mock_Command_run.call_args_list == [
+                call(
+                    [
+                        'cp', 'config_mount/path/to/private/key',
+                        '/home/hanauser/.ssh/id_rsa'
+                    ]
+                ),
+                call(['umount', 'config_mount'])
             ]
             assert mock_chmod.call_args_list == [
                 call('/home/hanauser/.ssh/', 0o700),


### PR DESCRIPTION
Instead of specifying a base64 encoded private ssh key
string as part of the key element in the config file,
we now just read a file path reference which is expected
to exist on the storage location from where the config
file was read. The referenced file is copied as the
ssh private key of the configured user. This sets the
config file free from any secret data and Fixes #58