### PR TITLE
Allow reboot of the system via kexec

### DIFF
--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -17,8 +17,10 @@
 #
 import os
 from collections import namedtuple
+from collections import OrderedDict
 
 from azure_li_services.command import Command
+
 from azure_li_services.exceptions import (
     AzureHostedConfigFileNotFoundException,
     AzureHostedConfigFileSourceMountException
@@ -38,6 +40,39 @@ class Defaults(object):
     @classmethod
     def get_status_report_directory(self):
         return '/var/lib/azure_li_services'
+
+    @classmethod
+    def get_service_reports(self):
+        from azure_li_services.status_report import StatusReport
+        service_reports = []
+        unit_to_service_map = {
+            'config_lookup':
+                'azure-li-config-lookup',
+            'user':
+                'azure-li-user',
+            'install':
+                'azure-li-install',
+            'network':
+                'azure-li-network',
+            'call':
+                'azure-li-call',
+            'machine_constraints':
+                'azure-li-machine-constraints',
+            'system_setup':
+                'azure-li-system-setup',
+            'storage':
+                'azure-li-storage'
+        }
+        unit_to_service_map_ordered = OrderedDict(
+            sorted(unit_to_service_map.items())
+        )
+        for unit, service in unit_to_service_map_ordered.items():
+            report = StatusReport(
+                unit, init_state=False, systemd_service_name=service
+            )
+            report.load()
+            service_reports.append(report)
+        return service_reports
 
     @classmethod
     def get_config_file(self):

--- a/azure_li_services/status_report.py
+++ b/azure_li_services/status_report.py
@@ -34,10 +34,14 @@ class StatusReport(object):
 
     :param str service_name: name of the service
     """
-    def __init__(self, service_name, init_state=True):
+    def __init__(
+        self, service_name, init_state=True, systemd_service_name=None
+    ):
+        self.systemd_service_name = systemd_service_name
         self.status = {
             service_name: {
-                'success': None
+                'success': None,
+                'reboot': False
             }
         }
         self.service_name = service_name
@@ -59,6 +63,10 @@ class StatusReport(object):
         self.status[self.service_name]['success'] = False
         self._write()
 
+    def set_reboot_required(self):
+        self.status[self.service_name]['reboot'] = True
+        self._write()
+
     def load(self):
         if os.path.exists(self.status_file):
             with open(self.status_file, 'r') as report:
@@ -66,6 +74,12 @@ class StatusReport(object):
 
     def get_state(self):
         return self.status[self.service_name]['success']
+
+    def get_reboot(self):
+        return self.status[self.service_name]['reboot']
+
+    def get_systemd_service(self):
+        return self.systemd_service_name
 
     def _write(self):
         with open(self.status_file, 'w') as report:

--- a/azure_li_services/units/report.py
+++ b/azure_li_services/units/report.py
@@ -16,10 +16,9 @@
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-from collections import OrderedDict
 
 # project
-from azure_li_services.status_report import StatusReport
+from azure_li_services.defaults import Defaults
 
 
 def main():
@@ -29,34 +28,13 @@ def main():
     Report overall service status in an update to /etc/issue
     if not all services were successful
     """
-    unit_to_service_map = {
-        'config_lookup':
-            'azure-li-config-lookup',
-        'user':
-            'azure-li-user',
-        'install':
-            'azure-li-install',
-        'network':
-            'azure-li-network',
-        'call':
-            'azure-li-call',
-        'machine_constraints':
-            'azure-li-machine-constraints',
-        'system_setup':
-            'azure-li-system-setup',
-        'storage':
-            'azure-li-storage'
-    }
-    unit_to_service_map_ordered = OrderedDict(
-        sorted(unit_to_service_map.items())
-    )
+    service_reports = Defaults.get_service_reports()
+
     failed_services = []
-    for unit, service in unit_to_service_map_ordered.items():
-        report = StatusReport(unit, init_state=False)
-        report.load()
+    for report in service_reports:
         success = report.get_state()
         if not success:
-            failed_services.append(service)
+            failed_services.append(report.get_systemd_service())
 
     if failed_services:
         report_services_failed(failed_services)

--- a/test/data/default_grub
+++ b/test/data/default_grub
@@ -1,0 +1,1 @@
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash=silent crashkernel=160M,high crashkernel=80M,low"

--- a/test/data/some_service.report.yaml
+++ b/test/data/some_service.report.yaml
@@ -1,2 +1,3 @@
 some_service:
   success: true
+  reboot: true

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -45,3 +45,49 @@ class TestDefaults(object):
                 ),
                 call(['mount', '/dev/dvd', '/mnt'])
             ]
+
+    @patch('azure_li_services.status_report.StatusReport')
+    def test_get_service_reports(self, mock_StatusReport):
+        Defaults.get_service_reports()
+        assert mock_StatusReport.call_args_list == [
+            call(
+                'call',
+                systemd_service_name='azure-li-call',
+                init_state=False
+            ),
+            call(
+                'config_lookup',
+                systemd_service_name='azure-li-config-lookup',
+                init_state=False
+            ),
+            call(
+                'install',
+                systemd_service_name='azure-li-install',
+                init_state=False
+            ),
+            call(
+                'machine_constraints',
+                systemd_service_name='azure-li-machine-constraints',
+                init_state=False
+            ),
+            call(
+                'network',
+                systemd_service_name='azure-li-network',
+                init_state=False
+            ),
+            call(
+                'storage',
+                systemd_service_name='azure-li-storage',
+                init_state=False
+            ),
+            call(
+                'system_setup',
+                systemd_service_name='azure-li-system-setup',
+                init_state=False
+            ),
+            call(
+                'user',
+                systemd_service_name='azure-li-user',
+                init_state=False
+            )
+        ]

--- a/test/unit/status_report_test.py
+++ b/test/unit/status_report_test.py
@@ -23,6 +23,12 @@ class TestStatusReport(object):
                 call(':'),
                 call('\n'),
                 call('  '),
+                call('reboot'),
+                call(':'),
+                call(' '),
+                call('false'),
+                call('\n'),
+                call('  '),
                 call('success'),
                 call(':'),
                 call(' '),
@@ -46,7 +52,19 @@ class TestStatusReport(object):
             )
             assert self.report.status['some_service']['success'] is False
 
+    def test_set_reboot_required(self):
+        with patch('builtins.open', create=True) as mock_open:
+            self.report.set_reboot_required()
+            mock_open.assert_called_once_with(
+                '/var/lib/azure_li_services/some_service.report.yaml', 'w'
+            )
+            assert self.report.status['some_service']['reboot'] is True
+
+    def test_get_systemd_service(self):
+        assert self.report.get_systemd_service() is None
+
     def test_load(self):
         self.report.status_file = '../data/some_service.report.yaml'
         self.report.load()
         assert self.report.get_state() is True
+        assert self.report.get_reboot() is True

--- a/test/unit/units/cleanup_test.py
+++ b/test/unit/units/cleanup_test.py
@@ -1,10 +1,49 @@
-from unittest.mock import patch
+import io
+from unittest.mock import (
+    patch, Mock, MagicMock, call
+)
 from azure_li_services.units.cleanup import main
 
 
 class TestCleanup(object):
     @patch('azure_li_services.command.Command.run')
-    def test_main(self, mock_Command_run):
+    @patch('azure_li_services.units.cleanup.Defaults.get_service_reports')
+    def test_main(self, mock_get_service_reports, mock_Command_run):
+        report = Mock()
+        report.get_state.return_value = True
+        report.get_reboot.return_value = True
+        mock_get_service_reports.return_value = [report]
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = \
+                'BOOT_IMAGE=/vmlinuz-4.4.138-59-default ' + \
+                'root=UUID=8ef42f26 splash=silent'
+            main()
+            mock_open.assert_called_once_with('/proc/cmdline')
+            assert mock_Command_run.call_args_list == [
+                call(
+                    [
+                        'zypper', '--non-interactive',
+                        'remove', '--clean-deps', '--force-resolution',
+                        'azure-li-services'
+                    ]
+                ),
+                call(
+                    [
+                        'kexec',
+                        '--load', '/boot/vmlinuz',
+                        '--initrd', '/boot/initrd',
+                        '--command-line',
+                        'root=UUID=8ef42f26 splash=silent'
+                    ]
+                ),
+                call(
+                    ['kexec', '--exec']
+                )
+            ]
+        report.get_state.return_value = False
+        mock_Command_run.reset_mock()
         main()
         mock_Command_run.assert_called_once_with(
             [

--- a/test/unit/units/report_test.py
+++ b/test/unit/units/report_test.py
@@ -6,11 +6,12 @@ from azure_li_services.units.report import main
 
 
 class TestReport(object):
-    @patch('azure_li_services.units.report.StatusReport')
-    def test_main(self, mock_StatusReport):
+    @patch('azure_li_services.units.report.Defaults.get_service_reports')
+    def test_main(self, mock_get_service_reports):
         report = Mock()
+        report.get_systemd_service.return_value = 'service-name'
         report.get_state.return_value = False
-        mock_StatusReport.return_value = report
+        mock_get_service_reports.return_value = [report]
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             main()
@@ -18,27 +19,11 @@ class TestReport(object):
             mock_open.assert_called_once_with(
                 '/etc/issue', 'w'
             )
-            assert mock_StatusReport.call_args_list == [
-                call('call', init_state=False),
-                call('config_lookup', init_state=False),
-                call('install', init_state=False),
-                call('machine_constraints', init_state=False),
-                call('network', init_state=False),
-                call('storage', init_state=False),
-                call('system_setup', init_state=False),
-                call('user', init_state=False)
-            ]
             assert file_handle.write.call_args_list == [
                 call('\n'),
                 call('!!! DEPLOYMENT ERROR !!!'),
                 call('\n'),
-                call(
-                    'For details see: "systemctl status -l '
-                    'azure-li-call azure-li-config-lookup '
-                    'azure-li-install azure-li-machine-constraints '
-                    'azure-li-network azure-li-storage azure-li-system-setup '
-                    'azure-li-user"'
-                ),
+                call('For details see: "systemctl status -l service-name"'),
                 call('\n'),
                 call('\n')
             ]


### PR DESCRIPTION
This patch set is two fold:

First it adds a reboot flag to the status report and extends the cleanup service to allow for reboot of
the system via kexec if 

* all services were successful
* and at least one requests for reboot of the system exists in the result reports.

Second it extends the system setup service for the crash kernel memory setup in a way that the high
value if not set via the config file is calculated based on the amount of main memory. If the pre-configured values have changed the system_setup service also activates the reboot flag in its status report

This Fixes #64