### PR TITLE
Fixed access of unbound variable

### DIFF
--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -121,8 +121,8 @@ def setup_ssh_authorization(user):
             if user['username'] != 'root':
                 os.chown(ssh_auth_file, uid, gid)
         if 'ssh-private-key' in user:
+            ssh_key_source = Defaults.mount_config_source()
             try:
-                ssh_key_source = Defaults.mount_config_source()
                 private_key_file = user['ssh-private-key']
                 Command.run(
                     [


### PR DESCRIPTION
For the copy of the ssh private key the location providing the
key is mounted first and umounted when done. However the location
information from the mount is unknown in the scope of the final
block performing the umount. This Fixes #70