### PR TITLE
Check if mount location is already mounted

### DIFF
--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -101,6 +101,13 @@ class Defaults(object):
             name=os.path.basename(Defaults.get_config_file_name()),
             location='/mnt', label='azconfig'
         )
+        mountpoint_result = Command.run(
+            ['mountpoint', azure_config.location], raise_on_error=False
+        )
+        if mountpoint_result.returncode == 0:
+            # The azure_config location is already mounted
+            return azure_config
+
         lun_result = Command.run(
             ['mount', '--label', azure_config.label, azure_config.location],
             raise_on_error=False


### PR DESCRIPTION
Call the mountpoint command in mount_config_source prior to the
actual mount and perform the mount process only if the location
is not already an active mountpoint. This Fixes #74