### PR TITLE
Follow up fix for mount location checkup

### DIFF
--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -125,3 +125,9 @@ class Defaults(object):
                 )
 
         return azure_config
+
+    @classmethod
+    def umount_config_source(self, azure_config):
+        Command.run(
+            ['umount', '--lazy', azure_config.location], raise_on_error=False
+        )

--- a/azure_li_services/units/call.py
+++ b/azure_li_services/units/call.py
@@ -43,6 +43,6 @@ def main():
                 ]
             )
         finally:
-            Command.run(['umount', call_source.location])
+            Defaults.umount_config_source(call_source)
 
     status.set_success()

--- a/azure_li_services/units/config_lookup.py
+++ b/azure_li_services/units/config_lookup.py
@@ -56,4 +56,4 @@ def main():
         os.chmod(Defaults.get_config_file_name(), 0o600)
         status.set_success()
     finally:
-        Command.run(['umount', azure_config.location])
+        Defaults.umount_config_source(azure_config)

--- a/azure_li_services/units/install.py
+++ b/azure_li_services/units/install.py
@@ -97,6 +97,6 @@ def main():
                     ] + install_items
                 )
         finally:
-            Command.run(['umount', install_source.location])
+            Defaults.umount_config_source(install_source)
 
     status.set_success()

--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -160,7 +160,7 @@ def setup_ssh_authorization(user):
                 if user['username'] != 'root':
                     os.chown(ssh_key_file, uid, gid)
             finally:
-                Command.run(['umount', ssh_key_source.location])
+                Defaults.umount_config_source(ssh_key_source)
 
 
 def setup_sudo_authorization(user):

--- a/test/unit/units/call_test.py
+++ b/test/unit/units/call_test.py
@@ -28,6 +28,9 @@ class TestCall(object):
                 ]
             ),
             call(
-                ['umount', mock_mount_config_source.return_value.location]
+                [
+                    'umount', '--lazy',
+                    mock_mount_config_source.return_value.location
+                ], raise_on_error=False
             )
         ]

--- a/test/unit/units/config_lookup_test.py
+++ b/test/unit/units/config_lookup_test.py
@@ -23,11 +23,18 @@ class TestConfigLookup(object):
         mock_StatusReport.assert_called_once_with('config_lookup')
         status.set_success.assert_called_once_with()
         assert mock_Command_run.call_args_list == [
-            call([
-                'cp', mock_Path_which.return_value,
-                '/etc/suse_firstboot_config.yaml'
-            ]),
-            call(['umount', mock_mount_config_source.return_value.location])
+            call(
+                [
+                    'cp', mock_Path_which.return_value,
+                    '/etc/suse_firstboot_config.yaml'
+                ]
+            ),
+            call(
+                [
+                    'umount', '--lazy',
+                    mock_mount_config_source.return_value.location
+                ], raise_on_error=False
+            )
         ]
         mock_chmod.assert_called_once_with(
             '/etc/suse_firstboot_config.yaml', 0o600

--- a/test/unit/units/install_test.py
+++ b/test/unit/units/install_test.py
@@ -63,7 +63,12 @@ class TestInstall(object):
                     '--auto-agree-with-licenses', 'foo'
                 ]
             ),
-            call(['umount', mock_mount_config_source.return_value.location])
+            call(
+                [
+                    'umount', '--lazy',
+                    mock_mount_config_source.return_value.location
+                ], raise_on_error=False
+            )
         ]
 
     @patch('azure_li_services.units.install.Defaults.get_config_file')

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -105,7 +105,9 @@ class TestUser(object):
                         '/home/hanauser/.ssh/'
                     ]
                 ),
-                call(['umount', 'config_mount'])
+                call(
+                    ['umount', '--lazy', 'config_mount'], raise_on_error=False
+                )
             ]
             assert mock_chmod.call_args_list == [
                 call('/home/hanauser/.ssh/', 0o700),


### PR DESCRIPTION
Provides a umount_config_source method in the Defaults space to allow to perform an umount which succeeds even if the mountpoint is busy. The umount is performed as Lazy unmount and detaches the filesystem from the file hierarchy now, and clean up all references to this filesystem as soon as it is not busy anymore.

This Fixes #76