### PR TITLE
Allow to activate/deactivate the crash dump setup

### DIFF
--- a/azure_li_services/runtime_config.py
+++ b/azure_li_services/runtime_config.py
@@ -121,13 +121,9 @@ class RuntimeConfig(object):
         if self.config_data:
             return self.config_data.get('hostname')
 
-    def get_crash_kernel_high(self):
+    def get_crash_dump_config(self):
         if self.config_data:
-            return self.config_data.get('crash_kernel_high')
-
-    def get_crash_kernel_low(self):
-        if self.config_data:
-            return self.config_data.get('crash_kernel_low')
+            return self.config_data.get('crash_dump')
 
     def get_network_config(self):
         if self.config_data:

--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -17,13 +17,23 @@ schema = {
         'required': False,
         'type': 'string'
     },
-    'crash_kernel_high': {
+    'crash_dump': {
         'required': False,
-        'type': 'number'
-    },
-    'crash_kernel_low': {
-        'required': False,
-        'type': 'number'
+        'type': 'dict',
+        'schema': {
+            'activate': {
+                'required': False,
+                'type': 'boolean'
+            },
+            'crash_kernel_high': {
+                'required': False,
+                'type': 'number'
+            },
+            'crash_kernel_low': {
+                'required': False,
+                'type': 'number'
+            }
+        }
     },
     'machine_constraints': {
         'required': False,

--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -51,9 +51,7 @@ def main():
 
     try:
         set_kdump_service(
-            config.get_crash_kernel_high(),
-            config.get_crash_kernel_low(),
-            status
+            config.get_crash_dump_config(), status
         )
     except Exception as issue:
         system_setup_errors.append(issue)
@@ -137,8 +135,15 @@ def set_reboot_intervention():
             )
 
 
-def set_kdump_service(high, low, status):
-    calibrated = _kdump_calibrate(high, low)
+def set_kdump_service(config, status):
+    if config and config.get('activate') is False:
+        # activation of kernel crash dump setup is unwanted
+        return
+
+    calibrated = _kdump_calibrate(
+        config.get('crash_kernel_high') if config else None,
+        config.get('crash_kernel_low') if config else None
+    )
     grub_defaults_file = '/etc/default/grub'
     grub_defaults_data = None
     grub_defaults_digest = hashlib.sha256()

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -2,8 +2,11 @@ version: "20180614"
 instance_type: LargeInstance
 sku: "SR92"
 hostname: "azure"
-crash_kernel_low: 80
-crash_kernel_high: 160
+
+crash_dump:
+  activate: true
+  crash_kernel_low: 80
+  crash_kernel_high: 160
 
 machine_constraints:
   min_cores: 32

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -93,8 +93,7 @@ class TestRuntimeConfig(object):
     def test_get_hostname(self):
         assert self.runtime_config.get_hostname() == 'azure'
 
-    def test_get_crash_kernel_high(self):
-        assert self.runtime_config.get_crash_kernel_high() == 160
-
-    def test_get_crash_kernel_low(self):
-        assert self.runtime_config.get_crash_kernel_low() == 80
+    def test_get_crash_dump_config(self):
+        assert self.runtime_config.get_crash_dump_config() == {
+            'activate': True, 'crash_kernel_low': 80, 'crash_kernel_high': 160
+        }


### PR DESCRIPTION
The crash dump setup deserves its own section containing
the optional high/low values as well as a new switch to
control the activation of the setup process.
This Fixes #78