### PR TITLE
Fix inconsistent cleanup service

### DIFF
--- a/azure_li_services/units/cleanup.py
+++ b/azure_li_services/units/cleanup.py
@@ -46,6 +46,11 @@ def main():
             'azure-li-services'
         ]
     )
+    Command.run(
+        [
+            'systemctl', 'reset-failed'
+        ]
+    )
 
     if reboot_system:
         Command.run(

--- a/package/azure_li_services_spec_template
+++ b/package/azure_li_services_spec_template
@@ -85,6 +85,14 @@ install -D -m 644 systemd/azure-li-storage.service \
 install -D -m 644 systemd/azure-li-system-setup.service \
     %{buildroot}%{_unitdir}/azure-li-system-setup.service
 
+# %preun / %postun
+# While the package provides services all services are one-shot.
+# Additionally upon initial run, i.e. on first boot the package
+# itself gets removed vi the azure-li-cleanup implementation.
+# This means there is no package update path as the package will
+# be gone after initial boot. Therefore there is no need for
+# us of the "standard" systemd service handling macros.
+
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/*

--- a/package/azure_li_services_spec_template
+++ b/package/azure_li_services_spec_template
@@ -85,12 +85,6 @@ install -D -m 644 systemd/azure-li-storage.service \
 install -D -m 644 systemd/azure-li-system-setup.service \
     %{buildroot}%{_unitdir}/azure-li-system-setup.service
 
-%preun
-%service_del_preun azure-li-config-lookup.service azure-li-network.service azure-li-user.service azure-li-call.service azure-li-install.service azure-li-report.service azure-li-cleanup.service azure-li-machine-constraints.service azure-li-storage.service azure-li-system-setup.service
-
-%postun
-%service_del_postun azure-li-config-lookup.service azure-li-network.service azure-li-user.service azure-li-call.service azure-li-install.service azure-li-report.service azure-li-cleanup.service azure-li-machine-constraints.service azure-li-storage.service azure-li-system-setup.service
-
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/*

--- a/test/unit/units/cleanup_test.py
+++ b/test/unit/units/cleanup_test.py
@@ -31,6 +31,11 @@ class TestCleanup(object):
                 ),
                 call(
                     [
+                        'systemctl', 'reset-failed'
+                    ]
+                ),
+                call(
+                    [
                         'kexec',
                         '--load', '/boot/vmlinuz',
                         '--initrd', '/boot/initrd',
@@ -45,10 +50,17 @@ class TestCleanup(object):
         report.get_state.return_value = False
         mock_Command_run.reset_mock()
         main()
-        mock_Command_run.assert_called_once_with(
-            [
-                'zypper', '--non-interactive',
-                'remove', '--clean-deps', '--force-resolution',
-                'azure-li-services'
-            ]
-        )
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'zypper', '--non-interactive',
+                    'remove', '--clean-deps', '--force-resolution',
+                    'azure-li-services'
+                ]
+            ),
+            call(
+                [
+                    'systemctl', 'reset-failed'
+                ]
+            )
+        ]


### PR DESCRIPTION
The introduction of the pre/post scripts in the package which
runs systemd macros to delete the services causes a core dump
on zypper and prevents the cleanup service from actually
uninstalling the package. Thus I suggest to delete those
pre/post actions from the package and leave this in the hand
of the cleanup service using the reset-failed command from
systemd after uninstall of the package has been performed.
This references Issue #88